### PR TITLE
Barista missing rollup-ts from core dep list

### DIFF
--- a/utils/barista/package.json
+++ b/utils/barista/package.json
@@ -59,11 +59,9 @@
     "rollup-plugin-postcss": "^2.0.3",
     "rollup-plugin-react-svg": "^3.0.3",
     "rollup-plugin-terser": "^4.0.4",
+    "rollup-plugin-typescript2": "^0.25.3",
     "shelljs": "^0.8.3",
     "typescript": "^3.7.4",
     "yargs": "^12.0.5"
-  },
-  "devDependencies": {
-    "rollup-plugin-typescript2": "^0.25.3"
   }
 }


### PR DESCRIPTION
We had `rollup-plugin-typescript2` chilling in devDependencies which cooked it on the published version when trying to build (since it never actually installed)

![Uploading Screen Shot 2020-04-28 at 11.43.11 am.png…]()

e.g.

```
yarn run v1.22.4
$ barista build component
(node:59230) UnhandledPromiseRejectionWarning: Error: Cannot find module 'rollup-plugin-typescript2'
Require stack:
- /Users/jay/dev/campfire/client.campfire/node_modules/@coffee-shope/barista/commands/build/configs/rollup-component.js
- /Users/jay/dev/campfire/client.campfire/node_modules/@coffee-shope/barista/commands/build/index.js
- /Users/jay/dev/campfire/client.campfire/node_modules/@coffee-shope/barista/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:1014:15)
    at Function.Module._resolveFilename (/Users/jay/dev/campfire/client.campfire/node_modules/module-alias/index.js:49:29)
    at Function.Module._load (internal/modules/cjs/loader.js:884:27)
    at Module.require (internal/modules/cjs/loader.js:1074:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/Users/jay/dev/campfire/client.campfire/node_modules/@coffee-shope/barista/commands/build/configs/rollup-component.js:2:20)
    at Module._compile (internal/modules/cjs/loader.js:1185:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1205:10)
    at Module.load (internal/modules/cjs/loader.js:1034:32)
    at Function.Module._load (internal/modules/cjs/loader.js:923:14)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:59230) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:59230) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
✨  Done in 0.66s.
```