### PR TITLE
Enhancement: Individual barista build failures should fail the lerna build (build-all)

### DIFF
--- a/components/stack/src/index.tsx
+++ b/components/stack/src/index.tsx
@@ -8,7 +8,7 @@ const StackContainer = styled.div`
 `;
 
 const RowContainer = styled.div`
-  padding: ${props => props.padding}
+  padding: ${props => props.style?.padding}
 `;
 
 interface Props {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"create-util": "barista create util",
 		"create:util": "yarn create-util",
 		"bootstrap": "lerna bootstrap",
-		"build-all": "lerna run 'build'",
+		"build-all": "lerna run --no-bail --stream 'build'",
 		"publish-all": "lerna publish --ignore coffee-shope --message=\"chore: Publish packages\"",
 		"publish:all": "yarn publish-all",
 		"storybook": "start-storybook -p 9001 -c .storybook",

--- a/utils/barista/index.js
+++ b/utils/barista/index.js
@@ -15,7 +15,7 @@ const stories = require('./commands/stories');
 
 const log = (msg, chalkfn) => console.log(chalkfn ? chalkfn(msg) : msg);
 
-function readRuntimeConfigFile () {
+function readRuntimeConfigFile() {
   const configPath = `${path.resolve()}/.baristarc.js`;
 
   if (!fs.existsSync(configPath)) {
@@ -25,12 +25,12 @@ function readRuntimeConfigFile () {
   return require(configPath);
 }
 
-function getConfig (argv) {
+function getConfig(argv) {
   const flagConfig = {
     typescript: argv['no-typescript'] !== undefined ? argv['no-typescript'] !== 'true' : undefined,
     storybook: argv['no-storybook'] !== undefined ? argv['no-storybook'] !== 'true' : undefined,
     organisation_name: argv['organisation-name'],
-    packages_dir: argv['packages-dir']
+    packages_dir: argv['packages-dir'],
   };
 
   const config = readRuntimeConfigFile();
@@ -62,7 +62,7 @@ function getConfig (argv) {
   }
 }
 
-function run(command, moduleType, name, argv) {
+async function run(command, moduleType, name, argv) {
   const config = getConfig(argv);
 
   if (!command) {
@@ -79,7 +79,15 @@ function run(command, moduleType, name, argv) {
     return stories();
   }
   log('No valid command specified', chalk.red);
+  throw '';
 }
 
-const [ command, moduleType, name ] = _.get(yargs, 'argv._', ['', '']);
-run(command, moduleType, name, yargs.argv);
+const [command, moduleType, name] = _.get(yargs, 'argv._', ['', '']);
+
+run(command, moduleType, name, yargs.argv).then(
+  () => {},
+  error => {
+    console.error(error.message);
+    process.exit(1);
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7290,18 +7290,7 @@ gzip-size@^3.0.0:
   dependencies:
     duplexer "^0.1.1"
 
-handlebars@^4.0.2:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
-  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
-  dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.1.2:
+handlebars@^4.0.2, handlebars@^4.1.2:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
   integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
@@ -7819,10 +7808,15 @@ inquirer@^6.2.0, inquirer@^6.2.2:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-interpret@1.2.0, interpret@^1.0.0, interpret@^1.2.0:
+interpret@1.2.0, interpret@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
@@ -12194,7 +12188,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.12.0, resolve@^1.1.6, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
+resolve@1.12.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -12208,7 +12202,7 @@ resolve@1.8.1:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.10.0, resolve@^1.12.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -12685,9 +12679,9 @@ shell-quote@1.6.1:
     jsonify "~0.0.0"
 
 shelljs@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
-  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
So previously if any of the packages failed to bundle/build the `build-all` command would be completely ignorant to that as `barista` would always succeed its `run` commands.

To fix we made sure that failed builds are properly caught and then gave the `run` command the ability to handle a rejected promise and exit the process with code 1.

To test, break the syntax in any barista-built component and run a `build-all`. The build will fail and log (one time too many) the error that was thrown up to the `run` command.

I don't know how to tell `yarn run` not to log the big gross object that includes a re-print of the error messages thrown, but I figure two error messages is better than none 🤷 

P.S. we didn't publish the last change that fixed the `rollup-plugin-typescript2` being a dev dependency meme so barista was broken hahha.

P.P.S sorry for never finding the time to do personal projects, we should still find the time to hang out